### PR TITLE
Update syntax to follow TF 0.11 and later rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,23 +10,23 @@ data aws_iam_policy_document assume_role {
 }
 
 resource aws_iam_role role {
-  assume_role_policy = "${data.aws_iam_policy_document.assume_role.json}"
-  name               = "${var.name}"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name               = var.name
 }
 
 resource aws_iam_role_policy_attachment basic {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role       = "${aws_iam_role.role.name}"
+  role       = aws_iam_role.role.name
 }
 
 resource aws_iam_role_policy_attachment additional {
-  count      = "${length(var.attachments)}"
-  policy_arn = "${element(var.attachments, count.index)}"
-  role       = "${aws_iam_role.role.name}"
+  count      = length(var.attachments)
+  policy_arn = element(var.attachments, count.index)
+  role       = aws_iam_role.role.name
 }
 
 resource aws_iam_role_policy inline {
-  count      = "${length(var.inline_policies)}"
-  policy     = "${element(var.inline_policies, count.index)}"
-  role       = "${aws_iam_role.role.id}"
+  count      = length(var.inline_policies)
+  policy     = element(var.inline_policies, count.index)
+  role       = aws_iam_role.role.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
 output role_arn {
   description = "IAM role ARN."
-  value       = "${aws_iam_role.role.arn}"
+  value       = aws_iam_role.role.arn
 }
 
 output role_name {
   description = "IAM role name."
-  value       = "${aws_iam_role.role.name}"
+  value       = aws_iam_role.role.name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,12 +4,12 @@ variable name {
 
 variable inline_policies {
   description = "Optional additional inline IAM policy documents."
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable attachments {
   description = "Optional additional attached IAM policy ARNs."
-  type        = "list"
+  type        = list(string)
   default     = []
 }


### PR DESCRIPTION
I just updated the syntax around variables and curly braces, in order to silence the warnings made by the syntac deprecation in 0.12.

> Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

At the same time, the type definitions are no longer strings since 0.11 but are to be used as method calls. More info below:

> Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "list" and write
list(string) instead to explicitly indicate that the list elements are
strings.